### PR TITLE
Update runtime, build packages individually

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.json
+++ b/org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.json
@@ -1,9 +1,9 @@
 {
     "id": "org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins",
-    "branch": "21.08",
+    "branch": "22.08",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
-    "runtime-version": "21.08",
-    "sdk": "org.freedesktop.Sdk//21.08",
+    "runtime-version": "stable",
+    "sdk": "org.freedesktop.Sdk//22.08",
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
@@ -11,23 +11,64 @@
         "prefix": "/app/extensions/Plugins/ChowDSP-Plugins"
     },
     "cleanup": [
-        "/bin",
-        "/share/applications",
-        "/share/bash-completion",
-        "/share/doc",
-        "/share/icons",
-        "/share/man",
-        "/lib/lv2",
-        "/lib/vst3",
-        "/lib/cmake",
-        "/include"
+        "/lib/lv2"
     ],
     "modules": [
         "shared-modules/linux-audio/lv2.json",
-        "shared-modules/linux-audio/jack2.json",
         {
-            "name": "ChowDSP-Plugins",
-            "buildsystem": "cmake",
+            "name": "ChowTapeModel",
+            "buildsystem": "cmake-ninja",
+            "no-make-install": true,
+            "subdir": "Plugin",
+            "config-opts": [
+                "-DCMAKE_AR=/usr/bin/gcc-ar",
+                "-DCMAKE_NM=/usr/bin/gcc-nm",
+                "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "cxxflags": "-I/app/extensions/Plugins/ChowDSP-Plugins/include"
+            },
+            "make-args": [
+                "CHOWTapeModel_CLAP",
+                "CHOWTapeModel_LV2",
+                "CHOWTapeModel_VST3"
+            ],
+            "post-install": [
+                "install -d ${FLATPAK_DEST}/lv2",
+                "cp -R ./CHOWTapeModel_artefacts/Release/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
+                "strip ${FLATPAK_DEST}/lv2/CHOWTapeModel.lv2/*.so",
+                "install -d ${FLATPAK_DEST}/vst3",
+                "cp -R ./CHOWTapeModel_artefacts/Release/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
+                "strip ${FLATPAK_DEST}/vst3/CHOWTapeModel.vst3/Contents/*-linux/*.so",
+                "install -Dm755 -t ${FLATPAK_DEST}/clap ./CHOWTapeModel_artefacts/Release/CLAP/*.clap",
+                "strip ${FLATPAK_DEST}/clap/CHOWTapeModel.clap",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/ChowTapeModel ../LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/jatinchowdhury18/AnalogTapeModel.git",
+                    "tag": "v2.11.1",
+                    "commit": "1c173a57a72351abb3bf6e1f55079679ef9c35db",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/juce-616-header.patch",
+                    "options": [
+                        "-d",
+                        "Plugin/modules"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ChowMatrix",
+            "buildsystem": "cmake-ninja",
             "no-make-install": true,
             "config-opts": [
                 "-DCMAKE_AR=/usr/bin/gcc-ar",
@@ -38,30 +79,167 @@
             "build-options": {
                 "cxxflags": "-I/app/extensions/Plugins/ChowDSP-Plugins/include"
             },
+            "make-args": [
+                "ChowMatrix_LV2",
+                "ChowMatrix_VST3"
+            ],
             "post-install": [
                 "install -d ${FLATPAK_DEST}/lv2",
-                "cp -R ./ChowTape_Package-prefix/src/ChowTape_Package-build/CHOWTapeModel_artefacts/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
-                "cp -R ./ChowMatrix_Package-prefix/src/ChowMatrix_Package-build/ChowMatrix_artefacts/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
-                "cp -R ./ChowKick_Package-prefix/src/ChowKick_Package-build/ChowKick_artefacts/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
-                "cp -R ./KlonCentaur_Package-prefix/src/KlonCentaur_Package-build/ChowCentaur/ChowCentaur_artefacts/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
-                "strip ${FLATPAK_DEST}/lv2/*.lv2/*.so",
+                "cp -R ./ChowMatrix_artefacts/Release/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
+                "strip ${FLATPAK_DEST}/lv2/ChowMatrix.lv2/*.so",
                 "install -d ${FLATPAK_DEST}/vst3",
-                "cp -R ./ChowTape_Package-prefix/src/ChowTape_Package-build/CHOWTapeModel_artefacts/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
-                "cp -R ./ChowMatrix_Package-prefix/src/ChowMatrix_Package-build/ChowMatrix_artefacts/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
-                "cp -R ./ChowKick_Package-prefix/src/ChowKick_Package-build/ChowKick_artefacts/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
-                "cp -R ./KlonCentaur_Package-prefix/src/KlonCentaur_Package-build/ChowCentaur/ChowCentaur_artefacts/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
-                "strip ${FLATPAK_DEST}/vst3/*.vst3/Contents/*-linux/*.so",
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ./org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins",
-                "echo TODO install license"
+                "cp -R ./ChowMatrix_artefacts/Release/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
+                "strip ${FLATPAK_DEST}/vst3/ChowMatrix.vst3/Contents/*-linux/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/ChowMatrix LICENSE"
             ],
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/Chowdhury-DSP/releases.git",
-                    "commit": "65ae24bda76b23339e3698c49edeea9c164e2f7f",
-                    "disable-shallow-clone": true
+                    "url": "https://github.com/Chowdhury-DSP/ChowMatrix.git",
+                    "tag": "v1.3.0",
+                    "commit": "d355a33dced7353f6a75b7824d6f5e60e5582fc1",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ChowCentaur",
+            "buildsystem": "cmake-ninja",
+            "no-make-install": true,
+            "config-opts": [
+                "-DCMAKE_AR=/usr/bin/gcc-ar",
+                "-DCMAKE_NM=/usr/bin/gcc-nm",
+                "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "cxxflags": "-I/app/extensions/Plugins/ChowDSP-Plugins/include"
+            },
+            "make-args": [
+                "ChowCentaur_LV2",
+                "ChowCentaur_VST3"
+            ],
+            "post-install": [
+                "install -d ${FLATPAK_DEST}/lv2",
+                "cp -R ./ChowCentaur/ChowCentaur_artefacts/Release/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
+                "strip ${FLATPAK_DEST}/lv2/ChowCentaur.lv2/*.so",
+                "install -d ${FLATPAK_DEST}/vst3",
+                "cp -R ./ChowCentaur/ChowCentaur_artefacts/Release/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
+                "strip ${FLATPAK_DEST}/vst3/ChowCentaur.vst3/Contents/*-linux/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/ChowCentaur LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/jatinchowdhury18/KlonCentaur.git",
+                    "tag": "v1.4.0",
+                    "commit": "fdc026f8110d11b5a53fedf93d517316b57f4332",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ChowKick",
+            "buildsystem": "cmake-ninja",
+            "no-make-install": true,
+            "config-opts": [
+                "-DCMAKE_AR=/usr/bin/gcc-ar",
+                "-DCMAKE_NM=/usr/bin/gcc-nm",
+                "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "cxxflags": "-I/app/extensions/Plugins/ChowDSP-Plugins/include"
+            },
+            "make-args": [
+                "ChowKick_LV2",
+                "ChowKick_VST3"
+            ],
+            "post-install": [
+                "install -d ${FLATPAK_DEST}/lv2",
+                "cp -R ./ChowKick_artefacts/Release/LV2/*.lv2 ${FLATPAK_DEST}/lv2/",
+                "strip ${FLATPAK_DEST}/lv2/ChowKick.lv2/*.so",
+                "install -d ${FLATPAK_DEST}/vst3",
+                "cp -R ./ChowKick_artefacts/Release/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
+                "strip ${FLATPAK_DEST}/vst3/ChowKick.vst3/Contents/*-linux/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/ChowKick LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Chowdhury-DSP/ChowKick.git",
+                    "tag": "v1.1.1",
+                    "commit": "632c6ee3ae9d43cbbc21e5d2e372ceee1f7d8cfb",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ChowPhaser",
+            "buildsystem": "cmake-ninja",
+            "no-make-install": true,
+            "config-opts": [
+                "-DCMAKE_AR=/usr/bin/gcc-ar",
+                "-DCMAKE_NM=/usr/bin/gcc-nm",
+                "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "cxxflags": "-I/app/extensions/Plugins/ChowDSP-Plugins/include"
+            },
+            "make-args": [
+                "ChowPhaserMono_VST3",
+                "ChowPhaserStereo_VST3"
+            ],
+            "post-install": [
+                "install -d ${FLATPAK_DEST}/vst3",
+                "cp -R ./ChowPhaser*_artefacts/Release/VST3/*.vst3 ${FLATPAK_DEST}/vst3/",
+                "strip ${FLATPAK_DEST}/vst3/ChowPhaser*.vst3/Contents/*-linux/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/ChowPhaser LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/jatinchowdhury18/ChowPhaser.git",
+                    "disable-submodules": true,
+                    "tag": "v1.1.1",
+                    "commit": "80cf75a1f8b96eb1b1264a8114d925aaa7d5474e",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 },
+                {
+                    "type": "git",
+                    "url": "https://github.com/juce-framework/JUCE.git",
+                    "dest": "modules/JUCE",
+                    "commit": "99112cf71f0cc3aafa4622b62cf81f2b7df38f0b"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/Chowdhury-DSP/foleys_gui_magic.git",
+                    "dest": "modules/foleys_gui_magic",
+                    "commit": "9cab1a439d86cbf7942981b24ab59c60a55b7dcd"
+                }
+            ]
+        },
+        {
+            "name": "ChowDSP-Plugins",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 ./org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo ",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "path": "org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.metainfo.xml"

--- a/org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins.metainfo.xml
@@ -3,12 +3,21 @@
   <id>org.freedesktop.LinuxAudio.Plugins.ChowDSP-Plugins</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>ChowDSP-Plugins</name>
-  <summary>ChowDSP-Plugins, LV2/VST3 Plugins</summary>
+  <summary>Bundle of the ChowDSP LV2/VST3 Plugins</summary>
+  <description>
+    <p>This package include most of the ChowDSP plugins:</p>
+    <ul>
+      <li>ChowMatrix 1.3.0 (LV2/VST3)</li>
+      <li>ChowTapeModel 2.11.1 (LV2/VST3/CLAP)</li>
+      <li>ChowCentaur 1.4.0 (LV2/VST3)</li>
+      <li>ChowKick 1.1.1 (LV2/VST3)</li>
+      <li>ChowPhaser 1.1.1 (LV2)</li>
+    </ul>
+  </description>
   <url type="homepage">https://chowdsp.com/</url>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release date="2021-12-05" version="2.10.0" />
-    <release date="2021-09-09" version="2.9.0" />
+    <release date="2023-01-13" version="2023.01.13" />
   </releases>
 </component>

--- a/patches/juce-616-header.patch
+++ b/patches/juce-616-header.patch
@@ -1,0 +1,13 @@
+diff --git a/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h b/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+index 06c0a72..119f146 100644
+--- a/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
++++ b/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+@@ -23,6 +23,8 @@
+   ==============================================================================
+ */
+ 
++#include <utility>
++
+ namespace juce
+ {
+ 


### PR DESCRIPTION
This is my proposal to move forward with this.

The upstream meta package isn't up to date, I think it's better that way.

I have not included BYOD, I have a version with the standalone app available to be submitted.